### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This quick start demonstrates how to create an Azure Cosmos DB account for the C
 	* [Git](http://git-scm.com/).
     * [Python Driver](https://github.com/datastax/python-driver)
 
-1. Clone this repository using `git clone git@github.com:Azure-Samples/Azure-Samples/azure-cosmos-db-cassandra-python-getting-started.git cosmosdb`.
+1. Clone this repository using `git clone git@github.com:Azure-Samples/azure-cosmos-db-cassandra-python-getting-started.git cosmosdb`.
 
 2. Change directories to the repo using `cd cosmosdb`
 


### PR DESCRIPTION
Removed extra "Azure-Samples/" from git clone command

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Allows git clone command to work. The previous version led to a `Azure-Samples/Azure-Samples/azure-cosmos-db-cassandra-python-getting-started is not a valid repository name` error.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Just run `git clone git@github.com:Azure-Samples/azure-cosmos-db-cassandra-python-getting-started.git cosmosdb` and verify the repo clones. The old version of the path did not work.


## What to Check
Verify that the following are valid
* git repo clones normally instead of displaying an error

## Other Information
<!-- Add any other helpful information that may be needed here. -->