### PR TITLE
Add table count per keyspace

### DIFF
--- a/pyquickstart.py
+++ b/pyquickstart.py
@@ -16,6 +16,21 @@ def PrintTable(rows):
         t.add_row([r.user_id, r.user_name, r.user_bcity])
     print (t)
 
+def getTableCount(rows):
+    D = {}
+    for i in range(len(rows)):
+        if rows[i][0] in D:
+            D[rows[i][0]].append(rows[i][1])
+        else:
+            D[rows[i][0]]= []
+            D[rows[i][0]].append(rows[i][1])
+
+
+    s = PrettyTable(['keyspace_name', 'Num_of_Tables'])
+    for new_k, new_val in D.items():
+        s.add_row([new_k, len([item for item in new_val if item])])
+    print(s)
+
 #<authenticateAndConnect>
 ssl_context = SSLContext(PROTOCOL_TLSv1_2)
 ssl_context.verify_mode = CERT_NONE
@@ -43,6 +58,12 @@ session.execute("INSERT INTO  uprofile.user  (user_id, user_name , user_bcity) V
 session.execute("INSERT INTO  uprofile.user  (user_id, user_name , user_bcity) VALUES (%s,%s,%s)", [6,'Ateegk','Narewadi'])
 session.execute("INSERT INTO  uprofile.user  (user_id, user_name , user_bcity) VALUES (%s,%s,%s)", [7,'KannabbuS','Yamkanmardi'])
 #</insertData>
+
+#<GetNumberOfTables>
+print("\nTable count per keyspace")
+tableCount = session.execute("SELECT keyspace_name, table_name FROM system_schema.tables")
+getTableCount(tableCount._current_rows)
+#</GetNumberOfTables>
 
 #<queryAllItems>
 print ("\nSelecting All")


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Adding a function to show the number of tables in each keyspace within a Cassandra API for Azure Cosmos DB account.
## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X ] Other... Please describe: Sample app improvement as the code shows the number of tables in a keyspace.
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd azure-cosmos-db-cassandra-python-getting-started
git checkout addTableCount
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
python .\pyquickstart.py

## What to Check
Verify that the following are valid


## Other Information
<!-- Add any other helpful information that may be needed here. -->